### PR TITLE
Add test with arbitrary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ dipa-derive = {optional = true, version = "0.1", path = "./crates/dipa-derive"}
 
 [dev-dependencies]
 bincode = "1.3"
+serde_derive = "1"
+serde = "1"
+quickcheck = "0.8"
+quickcheck_macros = "0.8"
+quickcheck_derive = "0.3"
+rand = "0.6"
 
 [workspace]
 members = [

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+#[cfg(feature = "derive")]
+pub mod with_derive {
+    use bincode::Options;
+    use dipa::{DiffPatch, Diffable, Patchable};
+    use quickcheck::quickcheck;
+    use quickcheck_derive::Arbitrary;
+    use serde_derive::{Deserialize, Serialize};
+    use std::collections::BTreeMap;
+
+    #[derive(
+        Clone, Eq, PartialEq, PartialOrd, Ord, Debug, DiffPatch, Serialize, Deserialize, Arbitrary,
+    )]
+    pub struct Basic {
+        pub items: BTreeMap<u16, Vec<u8>>,
+    }
+
+    fn tester(mut a: Basic, b: Basic) -> bool {
+        let bin = bincode::options().with_varint_encoding();
+        let created = a.create_delta_towards(&b);
+
+        let serialized = bin.serialize(&created.delta).unwrap();
+        let deserialized: <Basic as dipa::Diffable<'_, '_, Basic>>::DeltaOwned =
+            bin.deserialize(&serialized).unwrap();
+
+        a.apply_patch(deserialized);
+        return a == b;
+    }
+
+    #[test]
+    fn test() {
+        quickcheck(tester as fn(Basic, Basic) -> bool);
+    }
+}


### PR DESCRIPTION
The test from #4 can be made accessible with -

```
cargo test --all-features
```

This PR adds the test. 
It still fails, however.